### PR TITLE
Visualizer fixes

### DIFF
--- a/concurrency/controller/script.py
+++ b/concurrency/controller/script.py
@@ -208,6 +208,12 @@ def _start(exe, terminalOutputFile, visualizerMode):
                 var_value = "Unlocked"
             else:
                 var_value = "Locked by " + owner['name']
+        else:
+            out = lldb.SBStream()
+            lldb_var.GetDescription(out)
+            desc = out.GetData()
+            loc = desc.index(" = ")
+            var_value = desc[loc + len(" = "):]
         return {'name': lldb_var.GetName(), 'type': lldb_var.GetTypeName(), 'value': var_value}
 
     ignore_set = set()
@@ -390,6 +396,10 @@ def _start(exe, terminalOutputFile, visualizerMode):
                     for local in frame.GetVariables(True, True, False, True):
                         locals.append(serializeVariable(thread_man, local))
                 thread_list.append({'name': thread['name'], 'state': thread_state, 'locals': locals})
+            frame = None
+            for frame in main_thread:
+                if isFrameUserCode(frame):
+                    break
             globals = frame.get_statics()
             globals_list = []
             for frame_var in globals:

--- a/concurrency/controller/script.py
+++ b/concurrency/controller/script.py
@@ -30,9 +30,9 @@ def debug_now(*args, **kwargs):
     sys.stdout.flush()
 def debug_print(*args, **kwargs):
     return
-    print(*args, file=sys.stderr, **kwargs)
-    sys.stderr.flush()
-    sys.stdout.flush()
+    #print(*args, file=sys.stderr, **kwargs)
+    #sys.stderr.flush()
+    #sys.stdout.flush()
 
 def do_nothing():
     pass
@@ -161,6 +161,7 @@ def _start(exe, terminalOutputFile, visualizerMode):
     hook_createThread_bp = target.BreakpointCreateByName("lldb_hook_createThread", target.GetExecutable().GetFilename())
     vcJoin_bp = target.BreakpointCreateByName("vcJoin", target.GetExecutable().GetFilename())
     hook_freeThread_bp = target.BreakpointCreateByName("lldb_hook_freeThread", target.GetExecutable().GetFilename())
+    hook_threadSleep_bp = target.BreakpointCreateByName("lldb_hook_threadSleep", target.GetExecutable().GetFilename())
 
     # Semaphore breakpoints
     vc_internal_registerSem_bp = target.BreakpointCreateByName("vc_internal_registerSem", target.GetExecutable().GetFilename())
@@ -430,6 +431,13 @@ def _start(exe, terminalOutputFile, visualizerMode):
                     process.Continue()
                     handledBreakpoint = True
                     continue
+                if isStoppedForBreakpoint(t, hook_threadSleep_bp):
+                    milliseconds = t.GetFrameAtIndex(0).FindVariable("milliseconds").GetValueAsSigned()
+                    thread_man.onSleepThread(t, milliseconds)
+                    t.StepInstruction(False)
+                    handledBreakpoint = True
+                    continue
+                    
             handlingBreakpoints = handledBreakpoint
         # Send the program state to the visualizer
         if chosen_cthread is not None:

--- a/concurrency/controller/script.py
+++ b/concurrency/controller/script.py
@@ -205,10 +205,13 @@ def _start(exe, terminalOutputFile, visualizerMode):
             yield thread['thread']
     def serializeVariable(thread_man, lldb_var):
         var_value = lldb_var.GetValue()
-        if lldb_var.GetTypeName() == 'CSSem *':
+        type_name = lldb_var.GetTypeName()
+        if type_name == 'CSSem *':
             var_value = thread_man.getSemaphoreValue(str(var_value))
-        elif lldb_var.GetTypeName() == 'CSMutex *':
+            type_name = "vcSem"
+        elif type_name == 'CSMutex *':
             owner = thread_man.getMutexOwner(str(var_value))
+            type_name = "vcMutex"
             if owner is None:
                 var_value = "Unlocked"
             else:
@@ -219,7 +222,7 @@ def _start(exe, terminalOutputFile, visualizerMode):
             desc = out.GetData()
             loc = desc.index(" = ")
             var_value = desc[loc + len(" = "):]
-        return {'name': lldb_var.GetName(), 'type': lldb_var.GetTypeName(), 'value': var_value}
+        return {'name': lldb_var.GetName(), 'type': type_name, 'value': var_value}
 
     ignore_set = set()
     respondToVisualizer({'type': 'hello'})

--- a/concurrency/controller/thread_manager.py
+++ b/concurrency/controller/thread_manager.py
@@ -125,12 +125,20 @@ class ThreadManager:
             debug_print("\tAdding back", woken_thread['name'], "to the ready list")
             self.ready_list2.append(woken_thread)
             woken_thread['state'] = 'ready'
-
+    def onCloseSem(self, lldb_thread, sem):
+        del self.semaphoreMap[sem]
+        if sem in self.semWaitLists:
+            del self.semWaitLists[sem]
+        debug_print("Semaphore closed")
     def onCreateThread(self, thread):
         thread['state'] = 'ready'
         self.managed_threads.append(thread)
         self.ready_list2.append(thread)
         debug_print("Created thread:", thread['name'])
+    def onFreeThread(self, calling_thread, thread_ptr):
+        freed_thread = self.__lookupFromCSThreadPtr(thread_ptr)
+        freed_thread['csthread_ptr'] = 'N/A (freed)'
+        debug_print("Thread freed")
 
     def chooseThread(self):
         if len(self.ready_list2) <= 0:
@@ -208,6 +216,9 @@ class ThreadManager:
             #debug_print("A thread attempted to tryLock a mutex that it already owns")
             return True
         return False
+    def onCloseMutex(self, lldb_thread, mutex):
+        debug_print("Mutex closed")
+        del self.mutexMap[mutex]
     
     def getManagedThreads(self):
         return self.managed_threads

--- a/concurrency/controller/thread_manager.py
+++ b/concurrency/controller/thread_manager.py
@@ -19,7 +19,7 @@ class ThreadManager:
     semWaitLists = {}
     mutexMap = {}
     def __init__(self, main_lldb_thread):
-        main_thread = {'thread': main_lldb_thread, 'name': '#main_thread', 'state': 'ready', 'csthread_ptr': 'N/A'}
+        main_thread = {'thread': main_lldb_thread, 'name': 'Main Thread', 'state': 'ready', 'csthread_ptr': 'N/A'}
         self.ready_list2 = [main_thread]
         self.managed_threads.append(main_thread)
 

--- a/concurrency/lldb_lib.c
+++ b/concurrency/lldb_lib.c
@@ -85,7 +85,8 @@ int lldb_hook_semTryWait(CSSem *sem)
     int res;
     // LLDB
     fprintf(stderr, "Error\n");
-    return -9;
+    res = -9;
+    return res;
 }
 
 void lldb_hook_semClose(CSSem *sem)
@@ -114,7 +115,8 @@ int lldb_hook_mutexTryLock(CSMutex *mutex)
     int res;
     // LLDB
     fprintf(stderr, "Error\n");
-    return -9;
+    res = -9;
+    return res;
 }
 
 void lldb_hook_mutexClose(CSMutex *mutex)

--- a/concurrency/lldb_lib.c
+++ b/concurrency/lldb_lib.c
@@ -40,6 +40,11 @@ void lldb_hook_freeThread(CSThread *thread)
     // LLDB
 }
 
+void lldb_hook_threadSleep(int milliseconds)
+{
+    // LLDB
+}
+
 void vc_internal_init()
 {
     char *lldbMode = getenv("lldbMode");

--- a/concurrency/lldb_lib.c
+++ b/concurrency/lldb_lib.c
@@ -35,6 +35,11 @@ void vcJoin(CSThread *thread, void *ret)
     // pthread_join(thread, &ret);
 }
 
+void lldb_hook_freeThread(CSThread *thread)
+{
+    // LLDB
+}
+
 void vc_internal_init()
 {
     char *lldbMode = getenv("lldbMode");
@@ -75,6 +80,19 @@ void vcSignal(CSSem *sem)
     // LLDB
 }
 
+int lldb_hook_semTryWait(CSSem *sem)
+{
+    int res;
+    // LLDB
+    fprintf(stderr, "Error\n");
+    return -9;
+}
+
+void lldb_hook_semClose(CSSem *sem)
+{
+    // LLDB
+}
+
 // Mutexes
 void lldb_hook_registerMutex(CSMutex *mutex)
 {
@@ -91,20 +109,17 @@ void lldb_hook_unlockMutex(CSMutex *mutex)
     // LLDB
 }
 
-int lldb_hook_semTryWait(CSSem *sem)
-{
-    int res;
-    // LLDB
-    fprintf(stderr, "Error\n");
-    return res;
-}
-
 int lldb_hook_mutexTryLock(CSMutex *mutex)
 {
     int res;
     // LLDB
     fprintf(stderr, "Error\n");
-    return res;
+    return -9;
+}
+
+void lldb_hook_mutexClose(CSMutex *mutex)
+{
+    // LLDB
 }
 
 int main()

--- a/concurrency/lldb_lib.c
+++ b/concurrency/lldb_lib.c
@@ -91,6 +91,22 @@ void lldb_hook_unlockMutex(CSMutex *mutex)
     // LLDB
 }
 
+int lldb_hook_semTryWait(CSSem *sem)
+{
+    int res;
+    // LLDB
+    fprintf(stderr, "Error\n");
+    return res;
+}
+
+int lldb_hook_mutexTryLock(CSMutex *mutex)
+{
+    int res;
+    // LLDB
+    fprintf(stderr, "Error\n");
+    return res;
+}
+
 int main()
 {
     vc_internal_init();

--- a/concurrency/lldb_lib.h
+++ b/concurrency/lldb_lib.h
@@ -8,6 +8,7 @@ void *vc_internal_thread_wrapper(void *parameter);
 void lldb_hook_createThread(CSThread *thread, char *name);
 void lldb_waitForThreadStart(void);
 void lldb_hook_freeThread(CSThread *thread);
+void lldb_hook_threadSleep(int milliseconds);
 
 void vc_internal_registerSem(CSSem *sem, int initialValue, int maxValue);
 void vcWait(CSSem *sem);

--- a/concurrency/lldb_lib.h
+++ b/concurrency/lldb_lib.h
@@ -7,13 +7,16 @@ void vcJoin(CSThread *thread, void *ret);
 void *vc_internal_thread_wrapper(void *parameter);
 void lldb_hook_createThread(CSThread *thread, char *name);
 void lldb_waitForThreadStart(void);
+void lldb_hook_freeThread(CSThread *thread);
 
 void vc_internal_registerSem(CSSem *sem, int initialValue, int maxValue);
 void vcWait(CSSem *sem);
 void vcSignal(CSSem *sem);
 int lldb_hook_semTryWait(CSSem *sem);
+void lldb_hook_semClose(CSSem *sem);
 
 void lldb_hook_registerMutex(CSMutex *mutex);
 void lldb_hook_lockMutex(CSMutex *mutex);
 void lldb_hook_unlockMutex(CSMutex *mutex);
 int lldb_hook_mutexTryLock(CSMutex *mutex);
+void lldb_hook_mutexClose(CSMutex *mutex);

--- a/concurrency/lldb_lib.h
+++ b/concurrency/lldb_lib.h
@@ -11,7 +11,9 @@ void lldb_waitForThreadStart(void);
 void vc_internal_registerSem(CSSem *sem, int initialValue, int maxValue);
 void vcWait(CSSem *sem);
 void vcSignal(CSSem *sem);
+int lldb_hook_semTryWait(CSSem *sem);
 
 void lldb_hook_registerMutex(CSMutex *mutex);
 void lldb_hook_lockMutex(CSMutex *mutex);
 void lldb_hook_unlockMutex(CSMutex *mutex);
+int lldb_hook_mutexTryLock(CSMutex *mutex);

--- a/concurrency/mutexes.c
+++ b/concurrency/mutexes.c
@@ -306,9 +306,9 @@ int mutexStatus(CSMutex* mutex)
 // mutexClose - Close the mutex lock and free the struct.
 void mutexClose(CSMutex* mutex)
 {
-    if (isLldbActive)
+    if (isLldbActive && mutex->mutex == NULL)
     {
-        // TODO: cleanup
+        lldb_hook_mutexClose(mutex);
         free(mutex);
         return;
     }

--- a/concurrency/semaphores.c
+++ b/concurrency/semaphores.c
@@ -267,12 +267,13 @@ void platform_semSignal(CSSem* sem)
 // semClose - Close the semaphore and free the associated struct.
 void semClose(CSSem* sem)
 {
-    if (isLldbActive)
+    if (isLldbActive && sem->sem == NULL)
     {
-        //fprintf(stderr, "Warning: semClose is unimplemented!\n"); 
+        lldb_hook_semClose(sem);
         free(sem);
         return;
     }
+
     // Platform-dependent closure and memory management.
     #ifdef _WIN32 // Windows version.
         if(!CloseHandle(sem->sem))

--- a/concurrency/semaphores.c
+++ b/concurrency/semaphores.c
@@ -148,8 +148,12 @@ int semTryWait(CSSem* sem)
 {
     if (isLldbActive)
     {
-        fprintf(stderr, "Warning: semTryWait is unimplemented!\n"); 
-        return 0;
+        int success = lldb_hook_semTryWait(sem);
+        if (success)
+        {
+           sem->count = sem->count - 1; 
+        } 
+        return success;
     }
     // Platform-dependent trywaiting.
     #if defined(_WIN32) // Windows version
@@ -265,7 +269,8 @@ void semClose(CSSem* sem)
 {
     if (isLldbActive)
     {
-        fprintf(stderr, "Warning: semClose is unimplemented!\n"); 
+        //fprintf(stderr, "Warning: semClose is unimplemented!\n"); 
+        free(sem);
         return;
     }
     // Platform-dependent closure and memory management.

--- a/concurrency/threads.c
+++ b/concurrency/threads.c
@@ -122,13 +122,13 @@ void joinThread(CSThread *thread)
 // freeThread - Close the thread (if needed) and free the struct.
 void freeThread(CSThread *thread)
 {
+    if (isLldbActive) {
+        //fprintf(stderr, "freeThread: FIXME\n");
+    }
     // On Windows only, attempt to close the thread.
     // (On POSIX, the thread is closed during the join.)
     #ifdef _WIN32
-        if (isLldbActive) {
-            fprintf(stderr, "freeThread: FIXME\n");
-        }
-        else if (!CloseHandle(thread->thread))
+        if (!CloseHandle(thread->thread))
             vizconError("vcThreadStart/vcThreadReturn", GetLastError());
     #endif
 

--- a/concurrency/threads.c
+++ b/concurrency/threads.c
@@ -122,8 +122,9 @@ void joinThread(CSThread *thread)
 // freeThread - Close the thread (if needed) and free the struct.
 void freeThread(CSThread *thread)
 {
-    if (isLldbActive) {
-        //fprintf(stderr, "freeThread: FIXME\n");
+    if (isLldbActive)
+    {
+        lldb_hook_freeThread(thread);
     }
     // On Windows only, attempt to close the thread.
     // (On POSIX, the thread is closed during the join.)

--- a/concurrency/vcuserlibrary.c
+++ b/concurrency/vcuserlibrary.c
@@ -1,5 +1,7 @@
 #include "vcuserlibrary.h"
 
+extern int isLldbActive;
+
 // Pointers used to track all concurrency objects.
 CSThread *vizconThreadListHead, *vizconThreadList;
 CSSem *vizconSemListHead, *vizconSemList;
@@ -155,6 +157,11 @@ void** vcThreadReturn()
 //vcThreadSleep - Put the calling thread to sleep
 void vcThreadSleep(int milliseconds)
 {
+    if (isLldbActive)
+    {
+        lldb_hook_threadSleep(milliseconds);
+        return;
+    }
     #ifdef _WIN32
     Sleep(milliseconds);
     #else

--- a/src/main/platform.ts
+++ b/src/main/platform.ts
@@ -198,9 +198,14 @@ function launchProgram(path: string, port: Electron.MessagePortMain): void {
     }
     port.postMessage({ type: 'stdout', data: str });
   });
-
-  child.stderr.on('data', data => {
-    console.log(`child process error: "${data}"`);
+  child.stderr.on('data', (data: string) => {
+    console.log(`child process stderr: "${data}"`);
+    const str = data + '';
+    if (!haveSeenLldbMessage && str.startsWith('(lldb) script import sys;')) {
+      haveSeenLldbMessage = true;
+      return;
+    }
+    port.postMessage({ type: 'stdout', data: str });
   });
 }
 

--- a/src/types/props.d.ts
+++ b/src/types/props.d.ts
@@ -13,7 +13,7 @@ interface EditorProps {
 
 interface ThreadData {
   name: string;
-  state: 'running' | 'ready' | 'waiting' | 'completed';
+  state: 'running' | 'ready' | 'waiting (semaphore)' | 'waiting (mutex)' | 'waiting (vcJoin)' | 'sleeping' | 'completed';
   locals: VariableData[];
 }
 


### PR DESCRIPTION
* In the visualizer, display the main thread as "Main Thread" instead of "#main_thread"
* Use a different LLDB function to convert variable values to strings. It'll print the contents of arrays now (this probably only works with fixed-length arrays because otherwise LLDB would struggle to identify the length. It definitely doesn't work if you just malloc some memory, which will show as a pointer).
* Adds support for semTryWait and vcMutexTrylock in the LLDB backend for the user library.
    * Also better handling of mutexClose, semClose, freeThread, and vcThreadSleep
* In the visualizer, display mutex and semaphore types as "vcSem" and "vcMutex". These are hardcoded replacements for "CSSem *" and "CSMutex *" because I'm assuming there's no general way to do this for all `#defines`
* Fix the ThreadData type, which had an incorrect type definition for thread states